### PR TITLE
fix: Entities creating distinct attribute containers leaking said entities

### DIFF
--- a/src/main/java/io/github/apace100/apoli/mixin/DefaultAttributeContainerMixin.java
+++ b/src/main/java/io/github/apace100/apoli/mixin/DefaultAttributeContainerMixin.java
@@ -1,5 +1,7 @@
 package io.github.apace100.apoli.mixin;
 
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
 import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
 import io.github.apace100.apoli.access.OwnableAttributeContainer;
 import io.github.apace100.apoli.access.OwnableAttributeInstance;
@@ -15,17 +17,28 @@ import org.spongepowered.asm.mixin.injection.At;
 public abstract class DefaultAttributeContainerMixin implements OwnableAttributeContainer {
 
     @Unique
-    private final ThreadLocal<Entity> apoli$owner = new ThreadLocal<>();
+    private static final ThreadLocal<Cache<DefaultAttributeContainerMixin, Entity>> apoli$ownerMap =
+            ThreadLocal.withInitial(() -> CacheBuilder
+                    .newBuilder()
+                    .concurrencyLevel(1)
+                    .weakKeys()
+                    .weakValues()
+                    .build()
+            );
 
     @Override
     @Nullable
     public Entity apoli$getOwner() {
-        return apoli$owner.get();
+        return apoli$ownerMap.get().getIfPresent(this);
     }
 
     @Override
     public void apoli$setOwner(Entity owner) {
-        this.apoli$owner.set(owner);
+        if (owner != null) {
+            apoli$ownerMap.get().put(this, owner);
+        } else {
+            apoli$ownerMap.get().invalidate(this);
+        }
     }
 
     @ModifyExpressionValue(method = "getValue", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/attribute/DefaultAttributeContainer;require(Lnet/minecraft/registry/entry/RegistryEntry;)Lnet/minecraft/entity/attribute/EntityAttributeInstance;"))


### PR DESCRIPTION
This is a suboptimal fix for a suboptimal problem, but it does prevent permanent retention by its own ThreadLocal.

Both weak key and weak value being set is intentional, as either being strongly retained may prevent the entity from being GC'd.